### PR TITLE
Add indent-style rule for html, css, ts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,13 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
 
-[*.{js,json}]
+[*.{js,json,ts}]
+indent_size = 2
+
+[*.{html}]
+indent_size = 2
+
+[*.{css}]
 indent_size = 2
 
 [*.{yml}]


### PR DESCRIPTION
Update the editorconfig rule to enable 2 spaces on ts, html and css files
